### PR TITLE
Add notes on bidiff patch creation and parameter tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,13 @@ For example, if you export as a Linux/X11 app, your deliverables will look like 
 ```text
 libincremental_patch.so linux-test.pck          linux-test.x86_64
 ```
+
+## Tinkering with bidiff
+
+Install the barebones command line interface and create a diff:
+
+```sh
+git clone git@github.com:divvun/bidiff.git
+cd bidiff/crates/bic
+cargo install --path .
+```

--- a/README.md
+++ b/README.md
@@ -31,8 +31,15 @@ cd bidiff/crates/bic
 cargo install --path .
 ```
 
-It takes a long time (30min+?!) to make a diff of a 630MB file.
+Some reccs from the bidiff README:
+```text
+
+    partitions = (num_cores - 1) (this leaves a core for bookkeeping and compression)
+    chunk size = newer_size / (num_cores * k), where k is between 2 and 4;
+```
+
+Assume the new file is 688MB, and assume we have 4 cores.  Then:
 
 ```sh
-bic diff Big-0.1.0.pck Big-0.1.1.pck Big-0.1.0_to_0.1.1.diff
+time bic diff target/App-0.1.4.pck target/App-0.1.5-example.pck /tmp/tryagain-bidiff.diff --sort-partitions 3 --scan-chunk-size 57000000
 ```

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cd bidiff/crates/bic
 cargo install --path .
 ```
 
-Make a diff of `old new patch-output`:
+It takes a long time (30min+?!) to make a diff of a 630MB file.
 
 ```sh
 bic diff Big-0.1.0.pck Big-0.1.1.pck Big-0.1.0_to_0.1.1.diff

--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ git clone git@github.com:divvun/bidiff.git
 cd bidiff/crates/bic
 cargo install --path .
 ```
+
+Make a diff of `old new patch-output`:
+
+```sh
+bic diff Big-0.1.0.pck Big-0.1.1.pck Big-0.1.0_to_0.1.1.diff
+```

--- a/README.md
+++ b/README.md
@@ -31,11 +31,10 @@ cd bidiff/crates/bic
 cargo install --path .
 ```
 
-Some reccs from the bidiff README:
+Some reccs from the [bidiff README](https://github.com/divvun/bidiff#what-makes-bidiff-different):
 ```text
-
-    partitions = (num_cores - 1) (this leaves a core for bookkeeping and compression)
-    chunk size = newer_size / (num_cores * k), where k is between 2 and 4;
+partitions = (num_cores - 1) (this leaves a core for bookkeeping and compression)
+chunk size = newer_size / (num_cores * k), where k is between 2 and 4;
 ```
 
 Assume the new file is 688MB, and assume we have 4 cores.  Then we can accomplish this patch creation in about 160sec:

--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ Some reccs from the bidiff README:
     chunk size = newer_size / (num_cores * k), where k is between 2 and 4;
 ```
 
-Assume the new file is 688MB, and assume we have 4 cores.  Then:
+Assume the new file is 688MB, and assume we have 4 cores.  Then we can accomplish this patch creation in about 160sec:
 
 ```sh
 time bic diff target/App-0.1.4.pck target/App-0.1.5-example.pck /tmp/tryagain-bidiff.diff --sort-partitions 3 --scan-chunk-size 57000000
 ```
+
+The partitions and chunk size parameters are important.  You absolutely must tune these to your machine, or you'll be waiting for years for the algorithm to complete!


### PR DESCRIPTION
Adds notes about how to create a patch against a 688MB PCK file in a reasonable time frame.

One must appropriately tune the parameters to `bidiff diff`.  In our case we created a diff in 160 sec using a 4 core machine.

Advances #2.