### PR TITLE
Remove some hardcoding

### DIFF
--- a/Main.gd
+++ b/Main.gd
@@ -33,7 +33,7 @@ func _fetch_next_diff():
 			var delta_bin_request = get_node_or_null("DeltaBinRequest")
 			if delta_bin_request:
 				delta_bin_request.request(diff_url)
-			print("ok")
+			print("fetching from %s" % diff_url)
 			return MoreDiffs.YES
 		else:
 			printerr("Cannot apply patch: malformed delta response")
@@ -45,6 +45,7 @@ func _on_MetadataRequest_request_completed(result, response_code, headers, body)
 		print("Fetching %d patches" % json.result.size())
 		_deltas = json.result
 		_diffs_to_fetch = json.result
+		_fetch_next_diff()
 	else:
 		printerr("Not an array")
 

--- a/Main.gd
+++ b/Main.gd
@@ -52,7 +52,15 @@ func _on_MetadataRequest_request_completed(result, response_code, headers, body)
 
 func _on_DeltaBinRequest_request_completed(result, response_code, headers, body):
 	if response_code == 200:
-		var patch_name = _fetching['diff_url'].split("/").last()
+		var diff_url = _fetching['diff_url']
+		if !diff_url:
+			printerr("failed to determine diff URL to save patch")
+			return
+		var su = diff_url.split("/")
+		var patch_name = su[su.size() - 1]
+		if !patch_name:
+			printerr("failed to determine file name to save patch")
+			return
 		var file = File.new() 
 		file.open(patch_name, File.WRITE)
 		file.store_buffer(body)

--- a/Main.gd
+++ b/Main.gd
@@ -10,8 +10,8 @@ func _ready():
 		version_label.text = "Running v%s" % app_version
 	
 	var metadata_request = get_node_or_null("MetadataRequest")
-	if metadata_request:
-		metadata_request.request("https://jsonplaceholder.typicode.com/todos/1")
+	if metadata_request and app_version:
+		metadata_request.request("http://127.0.0.1:45819/deltas?from_version=%s" % app_version)
 	
 	var delta_bin_request = get_node_or_null("DeltaBinRequest")
 	if delta_bin_request:
@@ -20,7 +20,7 @@ func _ready():
 
 func _on_MetadataRequest_request_completed(result, response_code, headers, body):
 	var json = JSON.parse(body.get_string_from_utf8())
-	print("Fake metadata result: %s" % json.result)
+	print("Delta-server response: %s" % json.result)
 
 
 func _on_DeltaBinRequest_request_completed(result, response_code, headers, body):

--- a/admin/write-sample-deltas.sh
+++ b/admin/write-sample-deltas.sh
@@ -10,8 +10,8 @@ fi
 
 # needs a dummy entry to represent the beginning of time.
 # the URL and checksum values will be ignored
-write-delta --data-dir $DATA_DIR -r 0.0.0 -p 0.0.0 --diff-url "https://localhost:8080/nothing" --diff-b2bsum 0 --expected-pck-b2bsum 0
+write-delta --data-dir $DATA_DIR -r 0.0.0 -p 0.0.0 --diff-url "http://localhost:8080/nothing" --diff-b2bsum 0 --expected-pck-b2bsum 0
 
 
 # first update
-write-delta --data-dir $DATA_DIR -r 0.1.0 -p 0.0.0 --diff-url "https://localhost:8080/test-0.0.0_to_test-0.0.0-DELTA.bin" --diff-b2bsum 3de46aeb3a11efb998af4a7c1bcdf54d1a397df9d31883162942ac5cbab04dba1e7f8dc451d6b621ae80e4220c1767d9533795d4afc0b0cfffd7017f72e1f3cc --expected-pck-b2bsum 80417e1017a3be2e153fd5e8fbf342d30861a14ae15488c3cf1a850fac98e3c1f5a2e6c2262ce1bb70c3cd23c9a1a01fa8ba24fab9d24138849e81bdc8eebd49
+write-delta --data-dir $DATA_DIR -r 0.1.0 -p 0.0.0 --diff-url "http://localhost:8080/test-0.0.0_to_test-0.0.0-DELTA.bin" --diff-b2bsum 3de46aeb3a11efb998af4a7c1bcdf54d1a397df9d31883162942ac5cbab04dba1e7f8dc451d6b621ae80e4220c1767d9533795d4afc0b0cfffd7017f72e1f3cc --expected-pck-b2bsum 80417e1017a3be2e153fd5e8fbf342d30861a14ae15488c3cf1a850fac98e3c1f5a2e6c2262ce1bb70c3cd23c9a1a01fa8ba24fab9d24138849e81bdc8eebd49


### PR DESCRIPTION
Removes some hard-coded paths, allowing one patch to be applied based on values returned by a `delta-server`.

Advances #6.